### PR TITLE
Update nightly fuzz workflow to use `pkg/env` package path

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          packages=$(go list ./internal/env ./internal/store ./internal/migration ./internal/task ./internal/httpc ./internal/util)
+          packages=$(go list ./pkg/env ./internal/store ./internal/migration ./internal/task ./internal/httpc ./internal/util)
           for pkg in $packages; do
             echo "Running fuzz on $pkg"
             go test $pkg -run=^$ -fuzz=Fuzz -fuzztime=10m


### PR DESCRIPTION
- Adjusted `go list` command to reflect relocation of `env` package from `internal` to `pkg`.
- Ensured fuzz tests include updated package structure for consistency.